### PR TITLE
Feature/jaino/#17

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("com.wap.wapp.firebase")
     id("com.wap.wapp.compose")
     id("com.wap.wapp.hilt")
+    id("com.wap.wapp.navigation")
 }
 
 android {

--- a/app/src/main/java/com/wap/wapp/MainActivity.kt
+++ b/app/src/main/java/com/wap/wapp/MainActivity.kt
@@ -1,8 +1,6 @@
 package com.wap.wapp
 
 import android.os.Bundle
-import android.util.Log
-import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.navigation.NavController
@@ -39,7 +37,7 @@ class MainActivity : AppCompatActivity() {
         val typedArray = resources.obtainTypedArray(R.array.hide_bottomNavigation_fragments)
 
         for (index in 0..typedArray.length()) {
-            hideBottomNavigationFragments.add(typedArray.getResourceId(index, 0,))
+            hideBottomNavigationFragments.add(typedArray.getResourceId(index, 0))
         }
 
         typedArray.recycle()

--- a/app/src/main/res/navigation/nav_main.xml
+++ b/app/src/main/res/navigation/nav_main.xml
@@ -4,6 +4,7 @@
     android:id="@+id/main_nav"
     app:startDestination="@id/nav_splash">
 
+    <include app:graph="@navigation/nav_auth" />
     <include app:graph="@navigation/nav_manage" />
     <include app:graph="@navigation/nav_notice" />
     <include app:graph="@navigation/nav_profile" />

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -2,5 +2,7 @@
 <resources>
     <array name="hide_bottomNavigation_fragments">
         <item>@id/splashFragment</item>
+        <item>@id/signInFragment</item>
+        <item>@id/signUpFragment</item>
     </array>
 </resources>

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -42,5 +42,9 @@ gradlePlugin {
             id = "com.wap.wapp.hilt"
             implementationClass = "com.wap.wapp.plugin.AndroidHiltPlugin"
         }
+        create("androidNavigation") {
+            id = "com.wap.wapp.navigation"
+            implementationClass = "com.wap.wapp.plugin.AndroidNavigationPlugin"
+        }
     }
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -2,10 +2,6 @@ plugins{
     `kotlin-dsl`
 }
 
-kotlin {
-    jvmToolchain(17)
-}
-
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17

--- a/build-logic/convention/src/main/java/com/wap/wapp/plugin/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/com/wap/wapp/plugin/AndroidFeatureConventionPlugin.kt
@@ -11,6 +11,7 @@ class AndroidFeatureConventionPlugin: Plugin<Project>{
                 apply("com.wap.wapp.library")
                 apply("com.wap.wapp.compose")
                 apply("com.wap.wapp.hilt")
+                apply("com.wap.wapp.navigation")
             }
             configureBinding()
         }

--- a/build-logic/convention/src/main/java/com/wap/wapp/plugin/AndroidNavigationPlugin.kt
+++ b/build-logic/convention/src/main/java/com/wap/wapp/plugin/AndroidNavigationPlugin.kt
@@ -1,0 +1,24 @@
+package com.wap.wapp.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+
+class AndroidNavigationPlugin: Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("androidx.navigation.safeargs")
+            }
+
+            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+            dependencies{
+                "implementation"(libs.findLibrary("androidx-navigation-fragment-ktx").get())
+                "implementation"(libs.findLibrary("androidx-navigation-ui-ktx").get())
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/java/com/wap/wapp/plugin/AndroidNavigationPlugin.kt
+++ b/build-logic/convention/src/main/java/com/wap/wapp/plugin/AndroidNavigationPlugin.kt
@@ -18,6 +18,7 @@ class AndroidNavigationPlugin: Plugin<Project> {
             dependencies{
                 "implementation"(libs.findLibrary("androidx-navigation-fragment-ktx").get())
                 "implementation"(libs.findLibrary("androidx-navigation-ui-ktx").get())
+                "implementation"(libs.findLibrary("androidx-navigation-compose").get())
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ buildscript {
     dependencies {
         classpath(libs.android.build)
         classpath(libs.kotlin.gradle)
+        classpath(libs.androidx.navigation.safeargs)
         classpath(libs.hilt.gradle)
         classpath(libs.google.services.gradle)
         classpath(libs.firebase.crashlytics.gradle)
@@ -16,6 +17,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.androidx.navigation.safeargs) apply false
     alias(libs.plugins.dagger.hilt) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.firebase.crashlytics) apply false

--- a/core/data/src/main/java/com/wap/wapp/core/data/di/AuthRepositoryModule.kt
+++ b/core/data/src/main/java/com/wap/wapp/core/data/di/AuthRepositoryModule.kt
@@ -13,7 +13,7 @@ import dagger.hilt.android.scopes.ActivityScoped
 abstract class AuthRepositoryModule {
     @Binds
     @ActivityScoped
-    abstract fun providesAuthRepository(
+    abstract fun bindsAuthRepository(
         authRepositoryImpl: AuthRepositoryImpl,
     ): AuthRepository
 }

--- a/core/data/src/main/java/com/wap/wapp/core/data/di/DataModule.kt
+++ b/core/data/src/main/java/com/wap/wapp/core/data/di/DataModule.kt
@@ -13,7 +13,7 @@ import javax.inject.Singleton
 abstract class DataModule {
     @Binds
     @Singleton
-    abstract fun providesUserRepository(
+    abstract fun bindsUserRepository(
         userRepositoryImpl: UserRepositoryImpl,
     ): UserRepository
 }

--- a/core/data/src/main/java/com/wap/wapp/core/data/repository/user/UserRepository.kt
+++ b/core/data/src/main/java/com/wap/wapp/core/data/repository/user/UserRepository.kt
@@ -5,6 +5,8 @@ import com.wap.wapp.core.model.user.UserProfile
 interface UserRepository {
     suspend fun getUserProfile(userId: String): Result<UserProfile>
 
+    suspend fun getUserId(): Result<String>
+
     suspend fun postUserProfile(
         userId: String,
         userName: String,

--- a/core/data/src/main/java/com/wap/wapp/core/data/repository/user/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/wap/wapp/core/data/repository/user/UserRepositoryImpl.kt
@@ -14,6 +14,10 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getUserId(): Result<String> {
+        return userDataSource.getUserId()
+    }
+
     override suspend fun postUserProfile(
         userId: String,
         userName: String,

--- a/core/domain/src/main/java/com/wap/wapp/core/domain/usecase/auth/SignInUseCase.kt
+++ b/core/domain/src/main/java/com/wap/wapp/core/domain/usecase/auth/SignInUseCase.kt
@@ -22,15 +22,12 @@ class SignInUseCase @Inject constructor(
             userRepository.getUserProfile(userId)
                 .fold(
                     onFailure = { exception ->
-                        when (exception) {
-                            // 사용자를 조회할 수 없는 예외인 경우
-                            is IllegalStateException -> {
-                                SIGN_UP
-                            }
-                            else -> {
-                                throw (exception)
-                            }
+                        // 등록되지 않은 사용자인 경우
+                        if (exception is IllegalStateException) {
+                            return@fold SIGN_UP
                         }
+                        // 그 외의 예외인 경우
+                        throw (exception)
                     },
                     onSuccess = {
                         SIGN_IN

--- a/core/domain/src/main/java/com/wap/wapp/core/domain/usecase/auth/SignInUseCase.kt
+++ b/core/domain/src/main/java/com/wap/wapp/core/domain/usecase/auth/SignInUseCase.kt
@@ -6,6 +6,7 @@ import com.wap.wapp.core.domain.model.AuthState
 import com.wap.wapp.core.domain.model.AuthState.SIGN_IN
 import com.wap.wapp.core.domain.model.AuthState.SIGN_UP
 import dagger.hilt.android.scopes.ActivityScoped
+import java.lang.IllegalStateException
 import javax.inject.Inject
 
 @ActivityScoped
@@ -21,13 +22,15 @@ class SignInUseCase @Inject constructor(
             userRepository.getUserProfile(userId)
                 .fold(
                     onFailure = { exception ->
-                        // 사용자를 조회할 수 없는 예외인 경우
-                        val userNotFoundException = IllegalStateException()
-                        if (exception == userNotFoundException) {
-                            SIGN_UP
+                        when (exception) {
+                            // 사용자를 조회할 수 없는 예외인 경우
+                            is IllegalStateException -> {
+                                SIGN_UP
+                            }
+                            else -> {
+                                throw (exception)
+                            }
                         }
-                        // 이외의 예외라면,
-                        throw (exception)
                     },
                     onSuccess = {
                         SIGN_IN

--- a/core/domain/src/main/java/com/wap/wapp/core/domain/usecase/user/PostUserProfileUseCase.kt
+++ b/core/domain/src/main/java/com/wap/wapp/core/domain/usecase/user/PostUserProfileUseCase.kt
@@ -9,16 +9,19 @@ class PostUserProfileUseCase @Inject constructor(
     private val userRepository: UserRepository,
 ) {
     suspend operator fun invoke(
-        userId: String,
         userName: String,
         studentId: String,
         registeredAt: String,
     ): Result<Unit> {
-        return userRepository.postUserProfile(
-            userId = userId,
-            userName = userName,
-            studentId = studentId,
-            registeredAt = registeredAt,
-        )
+        return runCatching {
+            val userId = userRepository.getUserId().getOrThrow()
+
+            userRepository.postUserProfile(
+                userId = userId,
+                userName = userName,
+                studentId = studentId,
+                registeredAt = registeredAt,
+            )
+        }
     }
 }

--- a/core/network/src/main/java/com/wap/wapp/core/network/di/AuthDataSourceModule.kt
+++ b/core/network/src/main/java/com/wap/wapp/core/network/di/AuthDataSourceModule.kt
@@ -13,7 +13,7 @@ import dagger.hilt.android.scopes.ActivityScoped
 abstract class AuthDataSourceModule {
     @Binds
     @ActivityScoped
-    abstract fun providesAuthDataSource(
+    abstract fun bindsAuthDataSource(
         authDataSourceImpl: AuthDataSourceImpl,
     ): AuthDataSource
 }

--- a/core/network/src/main/java/com/wap/wapp/core/network/di/FirebaseModule.kt
+++ b/core/network/src/main/java/com/wap/wapp/core/network/di/FirebaseModule.kt
@@ -1,0 +1,24 @@
+package com.wap.wapp.core.network.di
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object FirebaseModule {
+    @Provides
+    @Singleton
+    fun providesFirebaseAuth(): FirebaseAuth = Firebase.auth
+
+    @Provides
+    @Singleton
+    fun providesFirestore(): FirebaseFirestore = Firebase.firestore
+}

--- a/core/network/src/main/java/com/wap/wapp/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/wap/wapp/core/network/di/NetworkModule.kt
@@ -1,24 +1,20 @@
 package com.wap.wapp.core.network.di
 
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.ktx.auth
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.ktx.firestore
-import com.google.firebase.ktx.Firebase
+import com.wap.wapp.core.network.source.user.UserDataSource
+import com.wap.wapp.core.network.source.user.UserDataSourceImpl
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object NetworkModule {
-    @Provides
-    @Singleton
-    fun providesFirebaseAuth(): FirebaseAuth = Firebase.auth
+abstract class NetworkModule {
 
-    @Provides
+    @Binds
     @Singleton
-    fun providesFirestore(): FirebaseFirestore = Firebase.firestore
+    abstract fun bindsUserDataSource(
+        userDataSourceImpl: UserDataSourceImpl,
+    ): UserDataSource
 }

--- a/core/network/src/main/java/com/wap/wapp/core/network/source/user/UserDataSource.kt
+++ b/core/network/src/main/java/com/wap/wapp/core/network/source/user/UserDataSource.kt
@@ -7,4 +7,6 @@ interface UserDataSource {
     suspend fun postUserProfile(userProfileRequest: UserProfileRequest): Result<Unit>
 
     suspend fun getUserProfile(userId: String): Result<UserProfileResponse>
+
+    suspend fun getUserId(): Result<String>
 }

--- a/core/network/src/main/java/com/wap/wapp/core/network/source/user/UserDataSourceImpl.kt
+++ b/core/network/src/main/java/com/wap/wapp/core/network/source/user/UserDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.wap.wapp.core.network.source.user
 
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
 import com.wap.wapp.core.network.constant.USER_COLLECTION
@@ -10,6 +11,7 @@ import javax.inject.Inject
 
 class UserDataSourceImpl @Inject constructor(
     private val firebaseFirestore: FirebaseFirestore,
+    private val firebaseAuth: FirebaseAuth,
 ) : UserDataSource {
     override suspend fun postUserProfile(
         userProfileRequest: UserProfileRequest,
@@ -25,6 +27,12 @@ class UserDataSourceImpl @Inject constructor(
                     setOption,
                 )
                 .await()
+        }
+    }
+
+    override suspend fun getUserId(): Result<String> {
+        return runCatching {
+            checkNotNull(firebaseAuth.uid)
         }
     }
 

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signin/SignInBottomSheet.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signin/SignInBottomSheet.kt
@@ -13,11 +13,13 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -25,95 +27,116 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.wap.designsystem.WappTheme
+import com.wap.wapp.core.domain.model.AuthState
+import com.wap.wapp.core.domain.usecase.auth.SignInUseCase
 import com.wap.wapp.feature.auth.R
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun signInBottomSheet() {
+fun SignInBottomSheet(
+    signInUseCase: SignInUseCase,
+    onDismiss: () -> Unit,
+    navigateToNotice: () -> Unit,
+    navigateToSignUp: () -> Unit,
+) {
     val sheetState = rememberModalBottomSheetState()
-    var isSheetOpen by rememberSaveable {
-        mutableStateOf(false)
-    }
+    val coroutineScope = rememberCoroutineScope()
+    var email by rememberSaveable { mutableStateOf("") }
 
-    if (isSheetOpen) {
-        ModalBottomSheet(
-            sheetState = sheetState,
-            onDismissRequest = { isSheetOpen = false },
+    ModalBottomSheet(
+        sheetState = sheetState,
+        onDismissRequest = { onDismiss() },
+        containerColor = WappTheme.colors.backgroundBlack,
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
         ) {
-            Column(
-                modifier = Modifier.padding(16.dp),
+            Text(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                text = stringResource(id = R.string.sign_in),
+                style = WappTheme.typography.contentBold,
+                color = WappTheme.colors.white,
+                fontSize = 18.sp,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = stringResource(id = R.string.sign_in_email),
+                color = WappTheme.colors.white,
+                style = WappTheme.typography.labelRegular,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+
+            OutlinedTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = email,
+                onValueChange = { email = it },
+                placeholder = {
+                    Text(
+                        text = stringResource(id = R.string.sign_in_email_hint),
+                    )
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Email,
+                ),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = WappTheme.colors.white,
+                    focusedBorderColor = WappTheme.colors.yellow,
+                ),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = {
+                    coroutineScope.launch {
+                        signInUseCase(email = email)
+                            .onSuccess {
+                                when (it) {
+                                    AuthState.SIGN_IN -> { navigateToNotice() }
+                                    AuthState.SIGN_UP -> { navigateToSignUp() }
+                                }
+                            }
+                            .onFailure { throwable ->
+                                // onShowErrorSnackBar(throwable)
+                            }
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                enabled = email.isNotBlank(),
+                colors = ButtonDefaults.buttonColors(
+                    contentColor = WappTheme.colors.white,
+                    containerColor = WappTheme.colors.yellow,
+                    disabledContentColor = WappTheme.colors.white,
+                    disabledContainerColor = WappTheme.colors.gray1,
+                ),
+                shape = RoundedCornerShape(10.dp),
             ) {
                 Text(
-                    modifier = Modifier.align(Alignment.CenterHorizontally),
-                    text = stringResource(id = R.string.sign_in),
+                    text = stringResource(id = R.string.done),
                     style = WappTheme.typography.contentMedium,
-                    color = WappTheme.colors.white,
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Text(
-                    text = stringResource(id = R.string.sign_in_email),
-                    color = WappTheme.colors.white,
-                    style = WappTheme.typography.labelRegular,
-                )
-                var filledText = ""
-                OutlinedTextField(
-                    modifier = Modifier.fillMaxWidth(),
-                    value = filledText,
-                    onValueChange = { filledText = it },
-                    placeholder = {
-                        Text(
-                            text = stringResource(id = R.string.sign_in_email_hint),
-                        )
-                    },
-                    keyboardOptions = KeyboardOptions(
-                        keyboardType = KeyboardType.Email,
-                    ),
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Button(
-                    onClick = { },
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.buttonColors(
-                        contentColor = WappTheme.colors.white,
-                        containerColor = WappTheme.colors.gray1,
-                    ),
-                    shape = RoundedCornerShape(10.dp),
-                ) {
-                    Text(
-                        text = stringResource(id = R.string.done),
-                        style = WappTheme.typography.contentMedium,
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Divider(
-                    color = WappTheme.colors.white,
-                    thickness = 1.dp,
-                )
-                Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Center,
-                    text = stringResource(id = R.string.sign_in_find_email),
-                    style = WappTheme.typography.captionMedium,
-                    color = WappTheme.colors.yellow,
                 )
             }
-        }
-    }
-}
+            Spacer(modifier = Modifier.height(16.dp))
 
-@Preview
-@Composable
-fun previewSignUpScreen() {
-    WappTheme {
-        signInBottomSheet()
+            Divider(
+                color = WappTheme.colors.white,
+                thickness = 1.dp,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                text = stringResource(id = R.string.sign_in_find_email),
+                style = WappTheme.typography.captionMedium,
+                color = WappTheme.colors.yellow,
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+        }
     }
 }

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signin/SignInBottomSheet.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signin/SignInBottomSheet.kt
@@ -37,7 +37,7 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SignInBottomSheet(
+internal fun SignInBottomSheet(
     signInUseCase: SignInUseCase,
     onDismiss: () -> Unit,
     navigateToNotice: () -> Unit,

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signin/SignInFragment.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signin/SignInFragment.kt
@@ -1,0 +1,77 @@
+package com.wap.wapp.feature.auth.signin
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.core.net.toUri
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavOptions
+import androidx.navigation.fragment.findNavController
+import com.wap.designsystem.WappTheme
+import com.wap.wapp.core.domain.usecase.auth.SignInUseCase
+import com.wap.wapp.feature.auth.R
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class SignInFragment : Fragment() {
+
+    @Inject
+    lateinit var signInUseCase: SignInUseCase
+
+    private lateinit var composeView: ComposeView
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).also {
+            composeView = it
+        }
+    }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        composeView.setContent {
+            var isSheetOpen by rememberSaveable { mutableStateOf(false) }
+
+            WappTheme {
+                SignInScreen(
+                    navigateToNotice = { navigateToNotice() },
+                    openSignInSheet = { isSheetOpen = true },
+                )
+
+                if (isSheetOpen) {
+                    SignInBottomSheet(
+                        signInUseCase = signInUseCase,
+                        onDismiss = { isSheetOpen = false },
+                        navigateToSignUp = { navigateToSignUp() },
+                        navigateToNotice = { navigateToNotice() },
+                    )
+                }
+            }
+        }
+    }
+
+    private fun navigateToSignUp() {
+        findNavController().navigate(
+            SignInFragmentDirections.actionSignInFragmentToSignUpFragment(),
+        )
+    }
+
+    private fun navigateToNotice() {
+        findNavController().navigate(
+            "wapp://feature/nav_notice".toUri(),
+            NavOptions.Builder()
+                .setPopUpTo(R.id.signUpFragment, true)
+                .build(),
+        )
+    }
+}

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signin/SignInScreen.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signin/SignInScreen.kt
@@ -29,7 +29,7 @@ import com.wap.wapp.core.designresource.R
 import com.wap.wapp.feature.auth.R.string
 
 @Composable
-fun SignInScreen(
+internal fun SignInScreen(
     openSignInSheet: () -> Unit,
     navigateToNotice: () -> Unit,
 ) {

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signin/SignInScreen.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signin/SignInScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.wap.designsystem.WappTheme
@@ -31,114 +30,113 @@ import com.wap.wapp.feature.auth.R.string
 
 @Composable
 fun SignInScreen(
-    navigateToSignUp: () -> Unit,
+    openSignInSheet: () -> Unit,
     navigateToNotice: () -> Unit,
 ) {
-    WappTheme {
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = WappTheme.colors.backgroundBlack,
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = WappTheme.colors.backgroundBlack,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(32.dp),
         ) {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(32.dp),
-            ) {
-                Spacer(modifier = Modifier.height(32.dp))
-                Image(
-                    painter = painterResource(id = R.drawable.img_white_cat),
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .size(width = 230.dp, height = 230.dp),
-                    contentDescription = "WAPP ICON",
-                )
+            Spacer(modifier = Modifier.height(32.dp))
+            Image(
+                painter = painterResource(id = R.drawable.img_white_cat),
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .size(width = 230.dp, height = 230.dp),
+                contentDescription = "WAPP ICON",
+            )
 
-                Row(
-                    modifier = Modifier.align(Alignment.CenterHorizontally),
-                ) {
-                    Column {
-                        Spacer(modifier = Modifier.height(40.dp))
-                        Text(
-                            text = stringResource(id = string.application_name),
-                            style = WappTheme.typography.titleBold,
-                            fontSize = 48.sp,
-                            color = WappTheme.colors.white,
-                        )
-                    }
+            Row(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+            ) {
+                Column {
+                    Spacer(modifier = Modifier.height(40.dp))
                     Text(
                         text = stringResource(id = string.application_name),
-                        fontSize = 48.sp,
                         style = WappTheme.typography.titleBold,
-                        color = WappTheme.colors.yellow,
+                        fontSize = 48.sp,
+                        color = WappTheme.colors.white,
+                    )
+                }
+                Text(
+                    text = stringResource(id = string.application_name),
+                    fontSize = 48.sp,
+                    style = WappTheme.typography.titleBold,
+                    color = WappTheme.colors.yellow,
+                )
+            }
+
+            Column {
+                ElevatedButton(
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    onClick = {
+                        openSignInSheet()
+                    },
+                    shape = RoundedCornerShape(10.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_github),
+                        contentDescription = stringResource(
+                            id = string.sign_in_github_description,
+                        ),
+                        modifier = Modifier.size(40.dp),
+                        tint = WappTheme.colors.black,
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Text(
+                        text = stringResource(id = string.sign_in_github_content),
+                        style = WappTheme.typography.contentMedium,
                     )
                 }
 
-                Column {
-                    ElevatedButton(
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp),
-                        onClick = {
-                            navigateToSignUp()
-                        },
-                        shape = RoundedCornerShape(10.dp),
-                    ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_github),
-                            contentDescription = stringResource(
-                                id = string.sign_in_github_description,
-                            ),
-                            modifier = Modifier.size(40.dp),
-                            tint = WappTheme.colors.black,
-                        )
-                        Spacer(modifier = Modifier.width(16.dp))
-                        Text(
-                            text = stringResource(id = string.sign_in_github_content),
-                            style = WappTheme.typography.contentMedium,
-                        )
-                    }
+                Spacer(modifier = Modifier.height(12.dp))
 
-                    Spacer(modifier = Modifier.height(12.dp))
-
-                    ElevatedButton(
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp),
-                        onClick = {
-                            navigateToNotice()
-                        },
-                        colors = ButtonDefaults.elevatedButtonColors(
-                            containerColor = WappTheme.colors.yellow,
-                            contentColor = WappTheme.colors.white,
+                ElevatedButton(
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    onClick = {
+                        navigateToNotice()
+                    },
+                    colors = ButtonDefaults.elevatedButtonColors(
+                        containerColor = WappTheme.colors.yellow,
+                        contentColor = WappTheme.colors.white,
+                    ),
+                    shape = RoundedCornerShape(10.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_balloon),
+                        contentDescription = stringResource(
+                            id = string.sign_in_non_member_description,
                         ),
-                        shape = RoundedCornerShape(10.dp),
-                    ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_balloon),
-                            contentDescription = stringResource(
-                                id = string.sign_in_non_member_description,
-                            ),
-                            modifier = Modifier.size(40.dp),
-                        )
-                        Spacer(modifier = Modifier.width(16.dp))
-                        Text(
-                            text = stringResource(id = string.sign_in_non_member_content),
-                            style = WappTheme.typography.contentMedium,
-                            color = WappTheme.colors.white,
-                        )
-                    }
+                        modifier = Modifier.size(40.dp),
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Text(
+                        text = stringResource(id = string.sign_in_non_member_content),
+                        style = WappTheme.typography.contentMedium,
+                        color = WappTheme.colors.white,
+                    )
                 }
             }
         }
     }
 }
 
-@Preview
+/*@Preview
 @Composable
 fun previewSignInScreen() {
     SignInScreen(
+
         navigateToSignUp = { },
         navigateToNotice = { },
     )
-}
+}*/

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpChip.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpChip.kt
@@ -16,7 +16,7 @@ import com.wap.designsystem.WappTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SignUpChip(
+internal fun SignUpChip(
     selectedItem: String,
     onSelected: (String) -> Unit,
 ) {

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpChip.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpChip.kt
@@ -10,9 +10,11 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.wap.designsystem.WappTheme
+import com.wap.wapp.feature.auth.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -20,7 +22,10 @@ internal fun SignUpChip(
     selectedItem: String,
     onSelected: (String) -> Unit,
 ) {
-    val itemsList = listOf("1학기", "2학기")
+    val itemsList = listOf(
+        stringResource(id = R.string.first_semester),
+        stringResource(id = R.string.second_semester),
+    )
     LazyRow(modifier = Modifier.fillMaxWidth()) {
         items(itemsList) { item ->
             FilterChip(

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpChip.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpChip.kt
@@ -9,10 +9,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -20,21 +16,17 @@ import com.wap.designsystem.WappTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SignUpChipGroup() {
+fun SignUpChip(
+    selectedItem: String,
+    onSelected: (String) -> Unit,
+) {
     val itemsList = listOf("1학기", "2학기")
-
-    var selectedItem by remember {
-        mutableStateOf(itemsList[0]) // initially, first item is selected
-    }
-
     LazyRow(modifier = Modifier.fillMaxWidth()) {
         items(itemsList) { item ->
             FilterChip(
                 modifier = Modifier.padding(horizontal = 6.dp),
                 selected = (item == selectedItem),
-                onClick = {
-                    selectedItem = item
-                },
+                onClick = { onSelected(item) },
                 label = {
                     Text(
                         text = item,

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpFragment.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpFragment.kt
@@ -1,0 +1,59 @@
+package com.wap.wapp.feature.auth.signup
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.core.net.toUri
+import androidx.fragment.app.Fragment
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavOptions
+import androidx.navigation.fragment.findNavController
+import com.wap.designsystem.WappTheme
+import com.wap.wapp.feature.auth.R
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SignUpFragment : Fragment() {
+
+    private lateinit var composeView: ComposeView
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).also {
+            composeView = it
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        composeView.setContent {
+            WappTheme {
+                SignUpScreen(
+                    viewModel = hiltViewModel(),
+                    navigateToNotice = { navigateToNotice() },
+                    navigateToSignIn = { navigateToSignIn() },
+                )
+            }
+        }
+    }
+
+    private fun navigateToNotice() {
+        findNavController().navigate(
+            "wapp://feature/nav_notice".toUri(),
+            NavOptions.Builder()
+                .setPopUpTo(R.id.signUpFragment, true)
+                .build(),
+        )
+    }
+
+    private fun navigateToSignIn() {
+        findNavController().navigate(
+            SignUpFragmentDirections.actionSignUpFragmentToSignInFragment(),
+        )
+    }
+}

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpScreen.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpScreen.kt
@@ -1,6 +1,7 @@
 package com.wap.wapp.feature.auth.signup
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,184 +15,177 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.Icon
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
-import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.wap.designsystem.WappTheme
 import com.wap.wapp.core.designresource.R
 import com.wap.wapp.feature.auth.R.drawable.ic_card
 import com.wap.wapp.feature.auth.R.drawable.ic_door
 import com.wap.wapp.feature.auth.R.string
+import com.wap.wapp.feature.auth.signup.SignUpViewModel.SignUpEvent
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
-fun SignUpScreen() {
-    WappTheme {
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = WappTheme.colors.backgroundBlack,
+fun SignUpScreen(
+    navigateToNotice: () -> Unit,
+    navigateToSignIn: () -> Unit,
+    viewModel: SignUpViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(true) {
+        viewModel.signUpEventFlow.collectLatest {
+            when (it) {
+                is SignUpEvent.Success -> {
+                    navigateToNotice()
+                }
+                is SignUpEvent.Failure -> {
+                    // onShowErrorSnackBar(it.throwable)
+                }
+            }
+        }
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = WappTheme.colors.backgroundBlack,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
         ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp),
+            Box(
+                modifier = Modifier.fillMaxWidth(),
             ) {
-                Box(
+                Image(
+                    painterResource(id = R.drawable.ic_back_btn),
+                    contentDescription = stringResource(id = string.back_button_description),
+                    modifier = Modifier
+                        .padding(vertical = 16.dp)
+                        .size(20.dp)
+                        .clickable { navigateToSignIn() },
+                )
+                Text(
+                    text = stringResource(id = string.sign_up),
+                    style = WappTheme.typography.titleBold,
+                    color = WappTheme.colors.white,
+                    fontSize = 20.sp,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp),
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Text(
+                text = stringResource(id = string.sign_up_title),
+                style = WappTheme.typography.titleBold,
+                color = WappTheme.colors.white,
+            )
+            Text(
+                text = stringResource(id = string.sign_up_content),
+                style = WappTheme.typography.contentMedium,
+                color = WappTheme.colors.gray1,
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Column(
+                verticalArrangement = Arrangement.spacedBy(32.dp),
+            ) {
+                SignUpTextField(
+                    iconDescription = stringResource(id = string.sign_up_name_description),
+                    text = viewModel.signUpName.collectAsState().value,
+                    title = stringResource(id = string.sign_up_name_title),
+                    onValueChanged = { name -> viewModel.setName(name) },
+                    hint = stringResource(id = string.sign_up_name_hint),
+                    supportingText = stringResource(id = string.sign_up_name_caption),
+                    icon = R.drawable.ic_profile,
                     modifier = Modifier.fillMaxWidth(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+                )
+
+                SignUpTextField(
+                    iconDescription = stringResource(
+                        id = string.sign_up_student_id_description,
+                    ),
+                    text = viewModel.signUpStudentId.collectAsState().value,
+                    title = stringResource(id = string.sign_up_student_id_title),
+                    onValueChanged = { name -> viewModel.setStudentId(name) },
+                    hint = stringResource(id = string.sign_up_student_id_hint),
+                    supportingText = stringResource(id = string.sign_up_student_id_caption),
+                    icon = ic_card,
+                    modifier = Modifier.fillMaxWidth(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                )
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Image(
-                        painterResource(id = R.drawable.ic_back_btn),
-                        contentDescription = stringResource(id = string.back_button_description),
-                        modifier = Modifier
-                            .padding(vertical = 16.dp)
-                            .size(20.dp),
+                    SignUpTextField(
+                        iconDescription = stringResource(
+                            id = string.sign_up_registered_at_description,
+                        ),
+                        text = viewModel.signUpYear.collectAsState().value,
+                        title = stringResource(id = string.sign_up_registered_at_title),
+                        onValueChanged = { name -> viewModel.setYear(name) },
+                        hint = stringResource(id = string.sign_up_registered_at_hint),
+                        supportingText = stringResource(
+                            id = string.sign_up_registered_at_caption,
+                        ),
+                        icon = ic_door,
+                        modifier = Modifier.width(150.dp),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     )
-                    Text(
-                        text = stringResource(id = string.sign_up),
-                        style = WappTheme.typography.titleBold,
-                        color = WappTheme.colors.white,
-                        fontSize = 20.sp,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 16.dp),
-                        textAlign = TextAlign.Center,
+
+                    SignUpChip(
+                        selectedItem = viewModel.signUpSemester.collectAsState().value,
+                        onSelected = { semester -> viewModel.setSemester(semester) },
                     )
                 }
 
-                Spacer(modifier = Modifier.height(32.dp))
-
-                Text(
-                    text = stringResource(id = string.sign_up_title),
-                    style = WappTheme.typography.titleBold,
-                    color = WappTheme.colors.white,
-                )
-                Text(
-                    text = stringResource(id = string.sign_up_content),
-                    style = WappTheme.typography.contentMedium,
-                    color = WappTheme.colors.gray1,
-                )
-
-                Spacer(modifier = Modifier.height(32.dp))
-
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(32.dp),
+                Button(
+                    onClick = { viewModel.postUserProfile() },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = WappTheme.colors.yellow,
+                    ),
+                    shape = RoundedCornerShape(10.dp),
                 ) {
-                    SignUpTextField(
-                        iconDescription = stringResource(id = string.sign_up_name_description),
-                        fieldName = stringResource(id = string.sign_up_name_title),
-                        fieldHint = stringResource(id = string.sign_up_name_hint),
-                        fieldSupportingText = stringResource(id = string.sign_up_name_caption),
-                        fieldIcon = R.drawable.ic_profile,
+                    Text(
+                        text = stringResource(id = string.done),
+                        style = WappTheme.typography.contentMedium,
+                        color = WappTheme.colors.white,
                     )
-
-                    SignUpTextField(
-                        iconDescription = stringResource(
-                            id = string.sign_up_student_id_description,
-                        ),
-                        fieldName = stringResource(id = string.sign_up_student_id_title),
-                        fieldHint = stringResource(id = string.sign_up_student_id_hint),
-                        fieldSupportingText = stringResource(
-                            id = string.sign_up_student_id_caption,
-                        ),
-                        fieldIcon = ic_card,
-                    )
-
-                    var dummyText = ""
-                    Column {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Icon(
-                                painter = painterResource(id = ic_door),
-                                contentDescription = stringResource(
-                                    id = string.sign_up_registered_at_description,
-                                ),
-                                tint = WappTheme.colors.white,
-                                modifier = Modifier.size(20.dp),
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(
-                                text = stringResource(id = string.sign_up_registered_at_title),
-                                color = WappTheme.colors.white,
-                                style = WappTheme.typography.contentBold,
-                            )
-                        }
-
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            TextField(
-                                value = dummyText,
-                                onValueChange = { dummyText = it },
-                                modifier = Modifier.width(150.dp),
-                                colors = TextFieldDefaults.textFieldColors(
-                                    textColor = WappTheme.colors.white,
-                                    backgroundColor = WappTheme.colors.backgroundBlack,
-                                    focusedIndicatorColor = WappTheme.colors.white,
-                                    unfocusedIndicatorColor = WappTheme.colors.white,
-                                ),
-                                placeholder = {
-                                    Text(
-                                        text = stringResource(
-                                            id = string.sign_up_registered_at_hint,
-                                        ),
-                                        color = WappTheme.colors.gray1,
-                                    )
-                                },
-                                keyboardOptions = KeyboardOptions(
-                                    keyboardType = KeyboardType.Number,
-                                ),
-                            )
-
-                            Spacer(modifier = Modifier.width(16.dp))
-
-                            SignUpChipGroup()
-                        }
-
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            text = stringResource(id = string.sign_up_registered_at_caption),
-                            color = WappTheme.colors.yellow,
-                            style = WappTheme.typography.captionRegular,
-                        )
-                    }
-
-                    Button(
-                        onClick = { },
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = WappTheme.colors.yellow,
-                        ),
-                        shape = RoundedCornerShape(10.dp),
-                    ) {
-                        Text(
-                            text = stringResource(id = string.done),
-                            style = WappTheme.typography.contentMedium,
-                            color = WappTheme.colors.white,
-                        )
-                    }
                 }
             }
         }
     }
 }
 
-@Preview
+/*@Preview
 @Composable
 fun previewSignUpScreen() {
-    SignUpScreen()
-}
+    SignUpScreen(
+        "",
+        navigateToNotice = { }
+    )
+}*/

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpScreen.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpScreen.kt
@@ -40,7 +40,7 @@ import com.wap.wapp.feature.auth.signup.SignUpViewModel.SignUpEvent
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable
-fun SignUpScreen(
+internal fun SignUpScreen(
     navigateToNotice: () -> Unit,
     navigateToSignIn: () -> Unit,
     viewModel: SignUpViewModel = hiltViewModel(),

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpTextField.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpTextField.kt
@@ -3,10 +3,10 @@ package com.wap.wapp.feature.auth.signup
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
@@ -21,34 +21,36 @@ import com.wap.designsystem.WappTheme
 @Composable
 fun SignUpTextField(
     iconDescription: String,
-    fieldName: String,
-    fieldHint: String,
-    fieldSupportingText: String,
-    fieldIcon: Int,
+    title: String,
+    text: String,
+    onValueChanged: (String) -> Unit,
+    hint: String,
+    supportingText: String,
+    icon: Int,
+    keyboardOptions: KeyboardOptions,
+    modifier: Modifier,
 ) {
-    var dummyText = ""
     Column {
         Row(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
-                painter = painterResource(id = fieldIcon),
+                painter = painterResource(id = icon),
                 contentDescription = iconDescription,
                 tint = WappTheme.colors.white,
                 modifier = Modifier.size(20.dp),
             )
             Spacer(modifier = Modifier.width(8.dp))
             Text(
-                text = fieldName,
+                text = title,
                 color = WappTheme.colors.white,
                 style = WappTheme.typography.contentBold,
             )
         }
         TextField(
-            value = dummyText,
-            onValueChange = { dummyText = it },
-            modifier = Modifier
-                .fillMaxWidth(),
+            value = text,
+            onValueChange = onValueChanged,
+            modifier = modifier,
             colors = TextFieldDefaults.textFieldColors(
                 textColor = WappTheme.colors.white,
                 backgroundColor = WappTheme.colors.backgroundBlack,
@@ -56,15 +58,13 @@ fun SignUpTextField(
                 unfocusedIndicatorColor = WappTheme.colors.white,
             ),
             placeholder = {
-                Text(
-                    text = fieldHint,
-                    color = WappTheme.colors.gray1,
-                )
+                Text(text = hint, color = WappTheme.colors.gray1)
             },
+            keyboardOptions = keyboardOptions,
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(
-            text = fieldSupportingText,
+            text = supportingText,
             color = WappTheme.colors.yellow,
             style = WappTheme.typography.captionRegular,
         )

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpTextField.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpTextField.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.unit.dp
 import com.wap.designsystem.WappTheme
 
 @Composable
-fun SignUpTextField(
+internal fun SignUpTextField(
     iconDescription: String,
     title: String,
     text: String,

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpViewModel.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpViewModel.kt
@@ -28,7 +28,7 @@ class SignUpViewModel @Inject constructor(
     private val _signUpYear: MutableStateFlow<String> = MutableStateFlow("")
     val signUpYear: StateFlow<String> get() = _signUpYear
 
-    private val _signUpSemester: MutableStateFlow<String> = MutableStateFlow("1학기")
+    private val _signUpSemester: MutableStateFlow<String> = MutableStateFlow(FIRST_SEMESTER)
     val signUpSemester: StateFlow<String> get() = _signUpSemester
 
     fun postUserProfile() {
@@ -59,6 +59,10 @@ class SignUpViewModel @Inject constructor(
 
     fun setSemester(semester: String) {
         _signUpSemester.value = semester
+    }
+
+    companion object {
+        const val FIRST_SEMESTER = "1학기"
     }
 
     sealed class SignUpEvent {

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpViewModel.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpViewModel.kt
@@ -1,0 +1,68 @@
+package com.wap.wapp.feature.auth.signup
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wap.wapp.core.domain.usecase.user.PostUserProfileUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class SignUpViewModel @Inject constructor(
+    private val postUserProfileUseCase: PostUserProfileUseCase,
+) : ViewModel() {
+
+    private val _signUpEventFlow = MutableSharedFlow<SignUpEvent>()
+    val signUpEventFlow: SharedFlow<SignUpEvent> get() = _signUpEventFlow
+
+    private val _signUpName: MutableStateFlow<String> = MutableStateFlow("")
+    val signUpName: StateFlow<String> get() = _signUpName
+
+    private val _signUpStudentId: MutableStateFlow<String> = MutableStateFlow("")
+    val signUpStudentId: StateFlow<String> get() = _signUpStudentId
+
+    private val _signUpYear: MutableStateFlow<String> = MutableStateFlow("")
+    val signUpYear: StateFlow<String> get() = _signUpYear
+
+    private val _signUpSemester: MutableStateFlow<String> = MutableStateFlow("1학기")
+    val signUpSemester: StateFlow<String> get() = _signUpSemester
+
+    fun postUserProfile() {
+        viewModelScope.launch {
+            postUserProfileUseCase(
+                userName = _signUpName.value,
+                studentId = _signUpStudentId.value,
+                registeredAt = "${_signUpYear.value} ${_signUpSemester.value}",
+            ).onSuccess {
+                _signUpEventFlow.emit(SignUpEvent.Success)
+            }.onFailure { throwable ->
+                _signUpEventFlow.emit(SignUpEvent.Failure(throwable))
+            }
+        }
+    }
+
+    fun setName(name: String) {
+        _signUpName.value = name
+    }
+
+    fun setStudentId(studentId: String) {
+        _signUpStudentId.value = studentId
+    }
+
+    fun setYear(year: String) {
+        _signUpYear.value = year
+    }
+
+    fun setSemester(semester: String) {
+        _signUpSemester.value = semester
+    }
+
+    sealed class SignUpEvent {
+        data object Success : SignUpEvent()
+        data class Failure(val throwable: Throwable) : SignUpEvent()
+    }
+}

--- a/feature/auth/src/main/res/navigation/nav_auth.xml
+++ b/feature/auth/src/main/res/navigation/nav_auth.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_auth"
+    app:startDestination="@id/signInFragment">
+
+    <fragment
+        android:id="@+id/signInFragment"
+        android:name="com.wap.wapp.feature.auth.signin.SignInFragment"
+        android:label="SignInFragment" >
+        <action
+            android:id="@+id/action_signInFragment_to_signUpFragment"
+            app:destination="@id/signUpFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/signUpFragment"
+        android:name="com.wap.wapp.feature.auth.signup.SignUpFragment"
+        android:label="SignUpFragment" >
+        <action
+            android:id="@+id/action_signUpFragment_to_signInFragment"
+            app:destination="@id/signInFragment" />
+    </fragment>
+
+    <deepLink app:uri="wapp://feature/nav_auth"/>
+</navigation>

--- a/feature/auth/src/main/res/values/strings.xml
+++ b/feature/auth/src/main/res/values/strings.xml
@@ -26,5 +26,7 @@
     <string name="sign_up_registered_at_hint">입부년도 입력</string>
     <string name="sign_up_registered_at_caption">회원님의 기수 정보를 알려드릴게요!</string>
     <string name="sign_up_registered_at_description">Door Icon</string>
+    <string name="first_semester">1학기</string>
+    <string name="second_semester">2학기</string>
     <string name="done">완료</string>
 </resources>

--- a/feature/splash/src/main/java/com/wap/wapp/feature/splash/SplashFragment.kt
+++ b/feature/splash/src/main/java/com/wap/wapp/feature/splash/SplashFragment.kt
@@ -27,13 +27,15 @@ class SplashFragment :
     }
 
     private fun handleEvent(event: SplashViewModel.SplashEvent) = when (event) {
-        is SplashViewModel.SplashEvent.TimerDone -> navigateToNotice()
+        is SplashViewModel.SplashEvent.TimerDone -> navigateToAuth()
     }
 
-    private fun navigateToNotice() {
+    private fun navigateToAuth() {
         findNavController().navigate(
-            "wapp://feature/nav_notice".toUri(),
-            NavOptions.Builder().setPopUpTo(R.id.splashFragment, true).build(),
+            "wapp://feature/nav_auth".toUri(),
+            NavOptions.Builder()
+                .setPopUpTo(R.id.splashFragment, true)
+                .build(),
         )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ hilt = "2.48"
 android-build = { module = "com.android.tools.build:gradle", version.ref = "gradleplugin" }
 kotlin-gradle = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 hilt-gradle = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
+androidx-navigation-safeargs = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref="androidx-navigation"}
 
 kotlin = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 
@@ -53,7 +54,6 @@ androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-kt
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
 androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "androidx-navigation" }
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "androidx-navigation" }
-
 
 compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
@@ -94,8 +94,6 @@ androidx = [
     "androidx-lifecycle-viewmodel",
     "androidx-fragment",
     "androidx-lifecycle-runtime",
-    "androidx-navigation-fragment-ktx",
-    "androidx-navigation-ui-ktx",
 ]
 
 compose = [
@@ -115,6 +113,7 @@ compose = [
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradleplugin" }
 android-library = { id = "com.android.library", version.ref = "gradleplugin" }
+androidx-navigation-safeargs= { id = "androidx.navigation.safeargs", version.ref = "androidx-navigation"}
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services-plugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ androidx-appcompat = "1.6.1"
 androidx-fragment = "1.6.1"
 androidx-activity = "1.7.2"
 androidx-lifecycle = "2.6.2"
+androidx-compose-hilt = "1.0.0"
 androidx-contstraintlayout = "2.1.4"
 androidx-test-junit = "1.1.5"
 androidx-test-espresso = "3.5.1"
@@ -54,6 +55,7 @@ androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-kt
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
 androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "androidx-navigation" }
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "androidx-navigation" }
+androidx-navigation-compose = { group = "androidx.navigation", name ="navigation-compose", version.ref = "androidx-navigation" }
 
 compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
@@ -67,6 +69,7 @@ compose-material3-windowSizeClass = { module = "androidx.compose.material3:mater
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
 compose-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
+compose-hilt = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "androidx-compose-hilt" }
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 
 google-services-gradle = { group = "com.google.gms", name = "google-services", version.ref = "google-services-plugin" }
@@ -107,7 +110,8 @@ compose = [
     "compose-material3-windowSizeClass",
     "compose-ui-tooling-preview",
     "compose-viewmodel",
-    "compose-activity"
+    "compose-activity",
+    "compose-hilt"
 ]
 
 [plugins]


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#17 회원가입 / 로그인 로직 결합 

## 2. 🔥변경된 점
이제 에뮬레이터에서 실제 로그인 및 회원 등록을 할 수 있음. 

Activity -> Fragment -> Screen -> Component 로 구성됨

UserId 가져오는 로직 추가 

## 3. 📸 스크린샷(선택)
![image](https://github.com/pknu-wap/WAPP/assets/77484719/f8d3ac34-0f01-474a-85bb-0a30c9f8cc85)
<img width="1279" alt="image" src="https://github.com/pknu-wap/WAPP/assets/77484719/a71e817b-0853-46d2-a297-5bb2033a6bc7">


## 4. 💡알게된 혹은 궁금한 사항들
Compose State Hoisting -> State를 최대한 위로 끌어올리기 -> SignUpViewModel로 모두 올렸음.

Compose <-> Xml 호환하는 방법 

중간에 삽질한번 해서, Compose로 Navigation 구현하는 방법도 알게 되었음 ㅎㅎ .. 

Hilt Scoped Annotation : 해당 컴포넌트보다 높은 계층의 컴포넌트를 가져올 수 있지만 낮은 계층은 불가능하다. 
- Activity Scoped 객체를 Fragment에서도 가능함. 