### PR TITLE
Feature/tgyuu/#74

### DIFF
--- a/app/src/main/java/com/wap/wapp/MainActivity.kt
+++ b/app/src/main/java/com/wap/wapp/MainActivity.kt
@@ -24,6 +24,7 @@ import com.wap.wapp.feature.auth.signin.navigation.signInNavigationRoute
 import com.wap.wapp.feature.auth.signup.navigation.signUpNavigationRoute
 import com.wap.wapp.feature.management.registration.event.navigation.eventRegistrationNavigationRoute
 import com.wap.wapp.feature.management.registration.survey.navigation.surveyRegistrationNavigationRoute
+import com.wap.wapp.feature.profile.profilesetting.navigation.profileSettingNavigationRoute
 import com.wap.wapp.feature.splash.navigation.splashNavigationRoute
 import com.wap.wapp.navigation.TopLevelDestination
 import com.wap.wapp.navigation.WappNavHost
@@ -91,6 +92,7 @@ private fun handleBottomBarState(
     signInNavigationRoute -> setBottomBarState(false)
     signUpNavigationRoute -> setBottomBarState(false)
     splashNavigationRoute -> setBottomBarState(false)
+    profileSettingNavigationRoute -> setBottomBarState(false)
     surveyRegistrationNavigationRoute -> setBottomBarState(false)
     eventRegistrationNavigationRoute -> setBottomBarState(false)
     else -> setBottomBarState(true)

--- a/feature/profile/src/main/java/com/wap/wapp/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/com/wap/wapp/feature/profile/ProfileScreen.kt
@@ -69,19 +69,17 @@ internal fun ProfileScreen(
                     .padding(start = 25.dp),
             )
 
-            if (role == Role.GUEST) {
-                return@Box
+            if (role != Role.GUEST) {
+                Image(
+                    painter =
+                    painterResource(id = drawable.ic_subtract),
+                    contentDescription = stringResource(id = R.string.profile_setting_description),
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .padding(end = 20.dp)
+                        .clickable { navigateToProfileSetting() },
+                )
             }
-
-            Image(
-                painter =
-                painterResource(id = drawable.ic_subtract),
-                contentDescription = stringResource(id = R.string.profile_setting_description),
-                modifier = Modifier
-                    .align(Alignment.CenterEnd)
-                    .padding(end = 20.dp)
-                    .clickable { navigateToProfileSetting() },
-            )
         }
 
         when (role) {

--- a/feature/profile/src/main/java/com/wap/wapp/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/com/wap/wapp/feature/profile/ProfileScreen.kt
@@ -44,7 +44,7 @@ internal fun ProfileRoute(
 
 @Composable
 internal fun ProfileScreen(
-    role: Role = Role.GUEST,
+    role: Role = Role.MANAGER,
     userName: String = "",
     eventsState: ProfileViewModel.EventsState,
     navigateToProfileSetting: () -> Unit,

--- a/feature/profile/src/main/java/com/wap/wapp/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/com/wap/wapp/feature/profile/ProfileScreen.kt
@@ -68,6 +68,11 @@ internal fun ProfileScreen(
                     .align(Alignment.CenterStart)
                     .padding(start = 25.dp),
             )
+
+            if (role == Role.GUEST) {
+                return@Box
+            }
+
             Image(
                 painter =
                 painterResource(id = drawable.ic_subtract),

--- a/feature/profile/src/main/java/com/wap/wapp/feature/profile/profilesetting/Const.kt
+++ b/feature/profile/src/main/java/com/wap/wapp/feature/profile/profilesetting/Const.kt
@@ -1,0 +1,7 @@
+package com.wap.wapp.feature.profile.profilesetting
+
+internal const val PRIVACY_POLICY_URL =
+    "https://www.notion.so/46beb7c4f3c2417bbec20eafd610d580?pvs=11"
+internal const val FAQ_URL = "https://www.notion.so/46beb7c4f3c2417bbec20eafd610d580?pvs=11"
+internal const val INQUIRY_URL = "https://www.notion.so/4fcb60f346c041248fd0d97d202a8a9a"
+internal const val TERMS_AND_POLICIES_URL = "https://www.notion.so/042dc914a6a34093a51658693e009411"

--- a/feature/profile/src/main/java/com/wap/wapp/feature/profile/profilesetting/ProfileSettingScreen.kt
+++ b/feature/profile/src/main/java/com/wap/wapp/feature/profile/profilesetting/ProfileSettingScreen.kt
@@ -1,5 +1,7 @@
 package com.wap.wapp.feature.profile.profilesetting
 
+import android.content.Context
+import android.content.Intent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -11,10 +13,12 @@ import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat.startActivity
+import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wap.designsystem.WappTheme
 import com.wap.designsystem.component.WappRowBar
@@ -27,8 +31,44 @@ internal fun ProfileSettingRoute(
     navigateToProfile: () -> Unit,
     viewModel: ProfileSettingViewModel = hiltViewModel(),
 ) {
-    ProfileSettingScreen(navigateToProfile)
+    val context = LocalContext.current
+
+    ProfileSettingScreen(
+        navigateToProfile = navigateToProfile,
+        onClickedPrivacyPolicy = {
+            navigateToUri(
+                context,
+                "https://www.notion.so/46beb7c4f3c2417bbec20eafd610d580?pvs=11",
+            )
+        },
+        onClickedFAQ = {
+            navigateToUri(
+                context,
+                "https://www.notion.so/FAQ-5832683da65048549e6a976b54d62875",
+            )
+        },
+        onClickedInquiry = {
+            navigateToUri(
+                context,
+                "https://www.notion.so/4fcb60f346c041248fd0d97d202a8a9a",
+            )
+        },
+        onClickedTermsAndPolicies = {
+            navigateToUri(
+                context,
+                "https://www.notion.so/042dc914a6a34093a51658693e009411",
+            )
+        },
+    )
 }
+
+private fun navigateToUri(context: Context, url: String) = startActivity(
+    context,
+    generateUriIntent(url),
+    null,
+)
+
+private fun generateUriIntent(url: String) = Intent(Intent.ACTION_VIEW, url.toUri())
 
 @Composable
 internal fun ProfileSettingScreen(
@@ -36,10 +76,10 @@ internal fun ProfileSettingScreen(
     onClickedAlarmSetting: () -> Unit = {},
     onClickedSignOut: () -> Unit = {},
     onClickedWithdrawal: () -> Unit = {},
-    onClickedInquiry: () -> Unit = {},
-    onClickedFAQ: () -> Unit = {},
-    onClickedTermsAndPolicies: () -> Unit = {},
-    onClickedPrivacyPolicy: () -> Unit = {},
+    onClickedInquiry: () -> Unit,
+    onClickedFAQ: () -> Unit,
+    onClickedTermsAndPolicies: () -> Unit,
+    onClickedPrivacyPolicy: () -> Unit,
 ) {
     val dividerThickness = 1.dp
     val dividerColor = WappTheme.colors.black42
@@ -156,10 +196,4 @@ internal fun ProfileSettingScreen(
             thickness = dividerThickness,
         )
     }
-}
-
-@Preview
-@Composable
-fun PreviewProfileMoreScreen() {
-    ProfileSettingScreen(navigateToProfile = {})
 }

--- a/feature/profile/src/main/java/com/wap/wapp/feature/profile/profilesetting/ProfileSettingScreen.kt
+++ b/feature/profile/src/main/java/com/wap/wapp/feature/profile/profilesetting/ProfileSettingScreen.kt
@@ -34,9 +34,9 @@ internal fun ProfileSettingRoute(
 internal fun ProfileSettingScreen(
     navigateToProfile: () -> Unit,
     onClickedAlarmSetting: () -> Unit = {},
-    onClickedSignout: () -> Unit = {},
+    onClickedSignOut: () -> Unit = {},
     onClickedWithdrawal: () -> Unit = {},
-    onClickedInquriy: () -> Unit = {},
+    onClickedInquiry: () -> Unit = {},
     onClickedFAQ: () -> Unit = {},
     onClickedTermsAndPolicies: () -> Unit = {},
     onClickedPrivacyPolicy: () -> Unit = {},
@@ -83,7 +83,7 @@ internal fun ProfileSettingScreen(
 
         WappRowBar(
             title = stringResource(id = com.wap.wapp.feature.profile.R.string.sign_out),
-            onClicked = onClickedSignout,
+            onClicked = onClickedSignOut,
         )
 
         Divider(
@@ -118,7 +118,7 @@ internal fun ProfileSettingScreen(
 
         WappRowBar(
             title = stringResource(id = com.wap.wapp.feature.profile.R.string.inquiry),
-            onClicked = onClickedInquriy,
+            onClicked = onClickedInquiry,
         )
 
         Divider(

--- a/feature/profile/src/main/java/com/wap/wapp/feature/profile/profilesetting/ProfileSettingScreen.kt
+++ b/feature/profile/src/main/java/com/wap/wapp/feature/profile/profilesetting/ProfileSettingScreen.kt
@@ -38,25 +38,25 @@ internal fun ProfileSettingRoute(
         onClickedPrivacyPolicy = {
             navigateToUri(
                 context,
-                "https://www.notion.so/46beb7c4f3c2417bbec20eafd610d580?pvs=11",
+                PRIVACY_POLICY_URL,
             )
         },
         onClickedFAQ = {
             navigateToUri(
                 context,
-                "https://www.notion.so/FAQ-5832683da65048549e6a976b54d62875",
+                FAQ_URL,
             )
         },
         onClickedInquiry = {
             navigateToUri(
                 context,
-                "https://www.notion.so/4fcb60f346c041248fd0d97d202a8a9a",
+                INQUIRY_URL,
             )
         },
         onClickedTermsAndPolicies = {
             navigateToUri(
                 context,
-                "https://www.notion.so/042dc914a6a34093a51658693e009411",
+                TERMS_AND_POLICIES_URL,
             )
         },
     )


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
closed #74 

## 2. 🔥변경된 점

**- 비회원으로 접속 시, 프로필 화면 우측 상단에 더 보기 페이지로 이동하는 이미지가 보이지 않습니다.**

**-프로필 더 보기 화면에서 하단 4개의 기능을 노션 페이지로 이동하게 만들었습니다.**

_(알람 설정, 로그아웃, 회원 탈퇴 기능은 아직 구현되어있지 않습니다.)_

## 3. 📸 스크린샷(선택)

UI가 바뀐 게 없어서 딱히 스크린 샷은 없습니다!

## 4. 💡알게된 혹은 궁금한 사항들

xml으로 웹 페이지로 이동할 때와 마찬가지로, 

```kotlin
startActivity(context, Intent(Intent.ACTION_VIEW, url.toUri()), null)
```

로 Compose에서도 마찬가지로 웹으로 이동할 수 있다.


<br><br><br>
이 때, context는 Composable 함수 내에서 아래와 같이 선언해서,

```kotlin
    val context = LocalContext.current
```

파라미터로 넘겨주면 사용할 수 있다.
