### PR TITLE
Fix/tgyuu/#112

### DIFF
--- a/app/src/main/java/com/wap/wapp/MainActivity.kt
+++ b/app/src/main/java/com/wap/wapp/MainActivity.kt
@@ -117,7 +117,7 @@ private fun handleBottomBarState(
     attendanceManagementNavigationRoute -> setBottomBarState(false)
     ManagementSurveyRoute.surveyFormRegistrationRoute -> setBottomBarState(false)
     eventRegistrationNavigationRoute -> setBottomBarState(false)
-    SurveyRoute.answerRoute("{id}") ->setBottomBarState(false)
+    SurveyRoute.answerRoute("{id}") -> setBottomBarState(false)
     else -> setBottomBarState(true)
 }
 

--- a/app/src/main/java/com/wap/wapp/MainActivity.kt
+++ b/app/src/main/java/com/wap/wapp/MainActivity.kt
@@ -1,23 +1,22 @@
 package com.wap.wapp
 
+import android.content.res.Resources
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -51,9 +50,10 @@ class MainActivity : ComponentActivity() {
         setContent {
             WappTheme {
                 val navController = rememberNavController()
+                val density = LocalDensity.current
+                val navigationBarHeight = getNavigationBarHeight(density)
 
                 Scaffold(
-                    modifier = Modifier.fillMaxSize(),
                     containerColor = WappTheme.colors.backgroundBlack,
                     bottomBar = {
                         val navBackStackEntry by
@@ -69,11 +69,6 @@ class MainActivity : ComponentActivity() {
                             },
                         )
 
-                        val systemBars = WindowInsets.systemBars
-                        val density = LocalDensity.current
-                        val bottomPadding =
-                            remember { with(density) { systemBars.getBottom(this).toDp() } }
-
                         WappBottomBar(
                             currentRoute = currentRoute,
                             bottomBarState = bottomBarState,
@@ -83,11 +78,12 @@ class MainActivity : ComponentActivity() {
                                     destination,
                                 )
                             },
-                            modifier = Modifier
-                                .padding(bottom = bottomPadding)
-                                .height(70.dp),
+                            modifier = Modifier.height(70.dp),
                         )
                     },
+                    modifier = Modifier
+                        .padding(bottom = navigationBarHeight)
+                        .fillMaxSize(),
                 ) { innerPadding ->
                     WappNavHost(
                         signInUseCase = signInUseCase,
@@ -131,5 +127,17 @@ private fun navigateToTopLevelDestination(
         }
         launchSingleTop = true
         restoreState = true
+    }
+}
+
+private fun getNavigationBarHeight(density: Density) = with(density) {
+    Resources.getSystem().run {
+        getDimensionPixelSize(
+            getIdentifier(
+                "navigation_bar_height",
+                "dimen",
+                "android",
+            ),
+        ).toDp()
     }
 }

--- a/core/designsystem/src/main/java/com/wap/designsystem/component/SubTopBar.kt
+++ b/core/designsystem/src/main/java/com/wap/designsystem/component/SubTopBar.kt
@@ -97,7 +97,7 @@ fun WappSubTopBarWithRightButton() {
             WappSubTopBar(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
+                    .padding(vertical = 16.dp),
                 titleRes = R.string.notice,
                 showRightButton = true,
             )
@@ -115,7 +115,7 @@ fun WappSubTopBarWithLeftButton() {
             WappSubTopBar(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
+                    .padding(vertical = 16.dp),
                 titleRes = R.string.notice,
                 showLeftButton = true,
             )
@@ -133,7 +133,7 @@ fun WappSubTopBarWithBothButton() {
             WappSubTopBar(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
+                    .padding(vertical = 16.dp),
                 titleRes = R.string.notice,
                 showRightButton = true,
                 showLeftButton = true,

--- a/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpScreen.kt
+++ b/feature/auth/src/main/java/com/wap/wapp/feature/auth/signup/SignUpScreen.kt
@@ -86,9 +86,7 @@ internal fun SignUpScreen(
                 .padding(horizontal = 16.dp),
         ) {
             WappSubTopBar(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 16.dp),
+                modifier = Modifier.fillMaxWidth(),
                 titleRes = string.sign_up,
                 showLeftButton = true,
                 onClickLeftButton = { navigateToSignIn() },

--- a/feature/management-event/src/main/java/com/wap/wapp/feature/management/event/edit/EventEditScreen.kt
+++ b/feature/management-event/src/main/java/com/wap/wapp/feature/management/event/edit/EventEditScreen.kt
@@ -175,7 +175,7 @@ internal fun EventEditScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .padding(16.dp),
+                .padding(vertical = 16.dp),
         ) {
             WappSubTopBar(
                 titleRes = R.string.event_edit,
@@ -187,12 +187,12 @@ internal fun EventEditScreen(
 
             EventEditStateIndicator(
                 eventRegistrationState = currentEditState,
-                modifier = Modifier.padding(top = 16.dp),
+                modifier = Modifier.padding(top = 16.dp, start = 20.dp, end = 20.dp),
             )
 
             EventRegistrationContent(
                 eventRegistrationState = currentEditState,
-                modifier = Modifier.padding(top = 50.dp),
+                modifier = Modifier.padding(top = 50.dp, start = 20.dp, end = 20.dp),
                 eventTitle = title,
                 eventContent = content,
                 location = location,

--- a/feature/management-event/src/main/java/com/wap/wapp/feature/management/event/registration/EventRegistrationContent.kt
+++ b/feature/management-event/src/main/java/com/wap/wapp/feature/management/event/registration/EventRegistrationContent.kt
@@ -165,7 +165,7 @@ private fun EventDetailsContent(
         WappButton(
             onClick = onNextButtonClicked,
             textRes = R.string.next,
-            modifier = Modifier.padding(vertical = 20.dp),
+            modifier = Modifier.padding(top = 20.dp),
         )
     }
 }
@@ -311,7 +311,6 @@ private fun EventScheduleContent(
         WappButton(
             onClick = onRegisterButtonClicked,
             textRes = R.string.register_event,
-            modifier = Modifier.padding(bottom = 20.dp),
         )
     }
 }

--- a/feature/management-event/src/main/java/com/wap/wapp/feature/management/event/registration/EventRegistrationScreen.kt
+++ b/feature/management-event/src/main/java/com/wap/wapp/feature/management/event/registration/EventRegistrationScreen.kt
@@ -149,7 +149,6 @@ internal fun EventRegistrationScreen(
                 titleRes = R.string.event_registration,
                 showLeftButton = true,
                 onClickLeftButton = onBackButtonClicked,
-                modifier = Modifier.padding(start = 10.dp),
             )
 
             EventRegistrationStateIndicator(

--- a/feature/management-survey/src/main/java/com/wap/wapp/feature/management/survey/SurveyFormStateIndicator.kt
+++ b/feature/management-survey/src/main/java/com/wap/wapp/feature/management/survey/SurveyFormStateIndicator.kt
@@ -18,10 +18,12 @@ import com.wap.designsystem.WappTheme
 @Composable
 internal fun SurveyFormStateIndicator(
     surveyRegistrationState: SurveyFormState,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier,
     ) {
         SurveyRegistrationStateProgressBar(surveyRegistrationState.progress)
         SurveyRegistrationStateText(surveyRegistrationState.page)

--- a/feature/management-survey/src/main/java/com/wap/wapp/feature/management/survey/edit/SurveyFormEditScreen.kt
+++ b/feature/management-survey/src/main/java/com/wap/wapp/feature/management/survey/edit/SurveyFormEditScreen.kt
@@ -104,7 +104,7 @@ internal fun SurveyFormEditScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues) // paddingValue padding
-                .padding(16.dp), // dp value padding
+                .padding(vertical = 16.dp), // dp value padding
             verticalArrangement = Arrangement.spacedBy(32.dp),
         ) {
             if (showDeleteSurveyDialog) {
@@ -127,6 +127,7 @@ internal fun SurveyFormEditScreen(
 
                 SurveyFormStateIndicator(
                     surveyRegistrationState = currentRegistrationState,
+                    modifier = Modifier.padding(horizontal = 20.dp),
                 )
             }
 
@@ -145,6 +146,7 @@ internal fun SurveyFormEditScreen(
                 showTimePicker = showTimePicker,
                 currentQuestionIndex = totalQuestionSize,
                 totalQuestionSize = totalQuestionSize,
+                modifier = Modifier.padding(horizontal = 20.dp),
                 onDatePickerStateChanged = { state -> showDatePicker = state },
                 onTimePickerStateChanged = { state -> showTimePicker = state },
                 onEventListChanged = { viewModel.getEventList() },

--- a/feature/management-survey/src/main/java/com/wap/wapp/feature/management/survey/registration/SurveyFormRegistrationScreen.kt
+++ b/feature/management-survey/src/main/java/com/wap/wapp/feature/management/survey/registration/SurveyFormRegistrationScreen.kt
@@ -77,7 +77,7 @@ internal fun SurveyRegistrationScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues) // paddingValue padding
-                .padding(top = 16.dp, start = 20.dp, end = 20.dp), // dp value padding
+                .padding(top = 16.dp), // dp value padding
         ) {
             WappSubTopBar(
                 titleRes = R.string.survey_registeration,
@@ -88,6 +88,7 @@ internal fun SurveyRegistrationScreen(
 
             SurveyFormStateIndicator(
                 surveyRegistrationState = currentRegistrationState,
+                modifier = Modifier.padding(horizontal = 20.dp),
             )
 
             SurveyFormContent(
@@ -105,6 +106,7 @@ internal fun SurveyRegistrationScreen(
                 showTimePicker = showTimePicker,
                 currentQuestionIndex = totalQuestionSize,
                 totalQuestionSize = totalQuestionSize,
+                modifier = Modifier.padding(horizontal = 20.dp),
                 onDatePickerStateChanged = { state -> showDatePicker = state },
                 onTimePickerStateChanged = { state -> showTimePicker = state },
                 onEventListChanged = { viewModel.getEventList() },

--- a/feature/management/src/main/java/com/wap/wapp/feature/management/ManagementScreen.kt
+++ b/feature/management/src/main/java/com/wap/wapp/feature/management/ManagementScreen.kt
@@ -1,6 +1,7 @@
-
 package com.wap.wapp.feature.management
 
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Scaffold
@@ -15,6 +16,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wap.designsystem.WappTheme
@@ -44,11 +46,17 @@ internal fun ManagementRoute(
 
         viewModel.userRole.collectLatest { userRoleUiState ->
             when (userRoleUiState) {
-                is ManagementViewModel.UserRoleUiState.Init -> { }
+                is ManagementViewModel.UserRoleUiState.Init -> {}
                 is ManagementViewModel.UserRoleUiState.Success -> {
                     when (userRoleUiState.userRole) {
-                        UserRole.GUEST -> { showGuestScreen = true }
-                        UserRole.MEMBER -> { showValidationScreen = true }
+                        UserRole.GUEST -> {
+                            showGuestScreen = true
+                        }
+
+                        UserRole.MEMBER -> {
+                            showValidationScreen = true
+                        }
+
                         UserRole.MANAGER -> viewModel.getEventSurveyList()
                     }
                 }
@@ -101,6 +109,7 @@ internal fun ManagementScreen(
     Scaffold(
         containerColor = WappTheme.colors.backgroundBlack,
         snackbarHost = { SnackbarHost(snackBarHostState) },
+        contentWindowInsets = WindowInsets(0.dp),
         topBar = {
             WappLeftMainTopBar(
                 titleRes = R.string.management,
@@ -109,7 +118,9 @@ internal fun ManagementScreen(
         },
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier.padding(paddingValues),
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize(),
         ) {
             item {
                 ManagementEventCard(

--- a/feature/management/src/main/java/com/wap/wapp/feature/management/ManagementScreen.kt
+++ b/feature/management/src/main/java/com/wap/wapp/feature/management/ManagementScreen.kt
@@ -1,7 +1,6 @@
 package com.wap.wapp.feature.management
 
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Scaffold
@@ -49,14 +48,8 @@ internal fun ManagementRoute(
                 is ManagementViewModel.UserRoleUiState.Init -> {}
                 is ManagementViewModel.UserRoleUiState.Success -> {
                     when (userRoleUiState.userRole) {
-                        UserRole.GUEST -> {
-                            showGuestScreen = true
-                        }
-
-                        UserRole.MEMBER -> {
-                            showValidationScreen = true
-                        }
-
+                        UserRole.GUEST -> { showGuestScreen = true }
+                        UserRole.MEMBER -> { showValidationScreen = true }
                         UserRole.MANAGER -> viewModel.getEventSurveyList()
                     }
                 }
@@ -64,9 +57,7 @@ internal fun ManagementRoute(
         }
 
         viewModel.errorFlow.collectLatest { throwable ->
-            snackBarHostState.showSnackbar(
-                message = throwable.toSupportingText(),
-            )
+            snackBarHostState.showSnackbar(message = throwable.toSupportingText())
         }
     }
 
@@ -117,11 +108,7 @@ internal fun ManagementScreen(
             )
         },
     ) { paddingValues ->
-        LazyColumn(
-            modifier = Modifier
-                .padding(paddingValues)
-                .fillMaxSize(),
-        ) {
+        LazyColumn(modifier = Modifier.padding(paddingValues)) {
             item {
                 ManagementEventCard(
                     eventsState = eventsState,

--- a/feature/management/src/main/java/com/wap/wapp/feature/management/ManagementSurveyCard.kt
+++ b/feature/management/src/main/java/com/wap/wapp/feature/management/ManagementSurveyCard.kt
@@ -44,7 +44,7 @@ internal fun ManagementSurveyCard(
             containerColor = WappTheme.colors.black25,
         ),
         modifier = Modifier
-            .padding(top = 20.dp)
+            .padding(vertical = 20.dp)
             .padding(horizontal = 8.dp),
     ) {
         Column(

--- a/feature/profile/src/main/java/com/wap/wapp/feature/profile/profilesetting/ProfileSettingScreen.kt
+++ b/feature/profile/src/main/java/com/wap/wapp/feature/profile/profilesetting/ProfileSettingScreen.kt
@@ -112,7 +112,7 @@ internal fun ProfileSettingScreen(
                 titleRes = string.more,
                 showLeftButton = true,
                 onClickLeftButton = navigateToProfile,
-                modifier = Modifier.padding(top = 20.dp),
+                modifier = Modifier.padding(top = 16.dp),
             )
 
             Row(


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
closed #112 

## 2. 🔥 변경된 점

**- 이제 바텀 바가 없는 화면에서도 하단 Navigation Bar에 UI가 가려지지 않아요!**

**- WappSubTopBar가 사용되는 UI에서 마진이 제각각이던걸 바로 잡았습니다.**

## 3. ✅ 꼭 확인해줬으면 하는 부분 

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들

**SystemBar (하단 네비바 혹은 상단 설정바) 의 정보를 얻는 방법이 여러가지가 있지만,**

```kotlin
 with(density) {
    Resources.getSystem().run {
        getDimensionPixelSize(
            getIdentifier(
                "navigation_bar_height",
                "dimen",
                "android",
            ),
        ).toDp()
    }
}
```

를 이용해서 얻을 수도 있다.

`"navigation_bar_height"`라고 되어있는 부분을 `"status_bar_height"` 로 고치면 **상단 설정 바 높이**도 얻을 수 있음.

출처 : pknujsp