### PR TITLE
Feature/jaino/#140

### DIFF
--- a/core/data/src/main/java/com/wap/wapp/core/data/repository/survey/SurveyRepositoryImpl.kt
+++ b/core/data/src/main/java/com/wap/wapp/core/data/repository/survey/SurveyRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.wap.wapp.core.data.repository.survey
 import com.wap.wapp.core.data.utils.toISOLocalDateTimeString
 import com.wap.wapp.core.model.survey.Survey
 import com.wap.wapp.core.model.survey.SurveyAnswer
+import com.wap.wapp.core.network.source.event.EventDataSource
 import com.wap.wapp.core.network.source.survey.SurveyDataSource
 import com.wap.wapp.core.network.source.user.UserDataSource
 import java.time.LocalDateTime
@@ -11,6 +12,7 @@ import javax.inject.Inject
 class SurveyRepositoryImpl @Inject constructor(
     private val surveyDataSource: SurveyDataSource,
     private val userDataSource: UserDataSource,
+    private val eventDataSource: EventDataSource,
 ) : SurveyRepository {
     override suspend fun getSurveyList(): Result<List<Survey>> =
         surveyDataSource.getSurveyList().mapCatching { surveyList ->
@@ -19,11 +21,12 @@ class SurveyRepositoryImpl @Inject constructor(
                     .mapCatching { userProfileResponse ->
                         val userName = userProfileResponse.toDomain().userName
 
-                        noticeNameResponse.mapCatching { noticeNameResponse ->
-                            val eventName = noticeNameResponse.toDomain()
+                        eventDataSource.getEvent(eventId = surveyResponse.eventId)
+                            .mapCatching { eventResponse ->
+                                val eventName = eventResponse.toDomain().title
 
-                            surveyResponse.toDomain(userName = userName, eventName = eventName)
-                        }.getOrThrow()
+                                surveyResponse.toDomain(userName = userName, eventName = eventName)
+                            }.getOrThrow()
                     }.getOrThrow()
             }
         }
@@ -35,11 +38,12 @@ class SurveyRepositoryImpl @Inject constructor(
                     .mapCatching { userProfileResponse ->
                         val userName = userProfileResponse.toDomain().userName
 
-                        noticeNameResponse.mapCatching { noticeNameResponse ->
-                            val eventName = noticeNameResponse.toDomain()
+                        eventDataSource.getEvent(eventId = eventId)
+                            .mapCatching { eventResponse ->
+                                val eventName = eventResponse.toDomain().title
 
-                            surveyResponse.toDomain(userName = userName, eventName = eventName)
-                        }.getOrThrow()
+                                surveyResponse.toDomain(userName = userName, eventName = eventName)
+                            }.getOrThrow()
                     }.getOrThrow()
             }
         }
@@ -51,11 +55,12 @@ class SurveyRepositoryImpl @Inject constructor(
                     .mapCatching { userProfileResponse ->
                         val userName = userProfileResponse.toDomain().userName
 
-                        noticeNameResponse.mapCatching { noticeNameResponse ->
-                            val eventName = noticeNameResponse.toDomain()
+                        eventDataSource.getEvent(eventId = surveyResponse.eventId)
+                            .mapCatching { eventResponse ->
+                                val eventName = eventResponse.toDomain().title
 
-                            surveyResponse.toDomain(userName = userName, eventName = eventName)
-                        }.getOrThrow()
+                                surveyResponse.toDomain(userName = userName, eventName = eventName)
+                            }.getOrThrow()
                     }.getOrThrow()
             }
         }
@@ -67,11 +72,12 @@ class SurveyRepositoryImpl @Inject constructor(
                     .mapCatching { userProfileResponse ->
                         val userName = userProfileResponse.toDomain().userName
 
-                        noticeNameResponse.mapCatching { noticeNameResponse ->
-                            val eventName = noticeNameResponse.toDomain()
+                        eventDataSource.getEvent(eventId = surveyResponse.eventId)
+                            .mapCatching { eventResponse ->
+                                val eventName = eventResponse.toDomain().title
 
-                            surveyResponse.toDomain(userName = userName, eventName = eventName)
-                        }.getOrThrow()
+                                surveyResponse.toDomain(userName = userName, eventName = eventName)
+                            }.getOrThrow()
                     }.getOrThrow()
             }
         }
@@ -82,11 +88,12 @@ class SurveyRepositoryImpl @Inject constructor(
                 .mapCatching { userProfileResponse ->
                     val userName = userProfileResponse.toDomain().userName
 
-                    noticeNameResponse.mapCatching { noticeNameResponse ->
-                        val eventName = noticeNameResponse.toDomain()
+                    eventDataSource.getEvent(eventId = surveyResponse.eventId)
+                        .mapCatching { eventResponse ->
+                            val eventName = eventResponse.toDomain().title
 
-                        surveyResponse.toDomain(userName = userName, eventName = eventName)
-                    }.getOrThrow()
+                            surveyResponse.toDomain(userName = userName, eventName = eventName)
+                        }.getOrThrow()
                 }.getOrThrow()
         }
 
@@ -113,9 +120,4 @@ class SurveyRepositoryImpl @Inject constructor(
 
     override suspend fun isSubmittedSurvey(surveyFormId: String, userId: String): Result<Boolean> =
         surveyDataSource.isSubmittedSurvey(surveyFormId, userId)
-
-    private val noticeNameResponse: Result<String> = Result.success("notice datasource dummy data")
-
-    // TODO 도메인 모델 구현을 위한 익스텐션, notice DataSource 구현 후 소거
-    private fun String.toDomain(): String = this
 }

--- a/core/model/src/main/java/com/wap/wapp/core/model/survey/Survey.kt
+++ b/core/model/src/main/java/com/wap/wapp/core/model/survey/Survey.kt
@@ -1,6 +1,9 @@
 package com.wap.wapp.core.model.survey
 
+import java.time.Duration
 import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 /*
 회원이 작성하는 설문 모델
@@ -15,4 +18,33 @@ data class Survey(
     val content: String,
     val surveyAnswerList: List<SurveyAnswer>,
     val surveyedAt: LocalDateTime,
-)
+) {
+    fun calculateSurveyedAt(): String {
+        val currentDateTime = LocalDateTime.now(TIME_ZONE_SEOUL)
+        val duration = Duration.between(surveyedAt, currentDateTime)
+
+        if (duration.toMinutes() == 0L) {
+            return "방금"
+        } else if (duration.toMinutes() < 60) {
+            val leftMinutes = duration.toMinutes().toString()
+            return leftMinutes + "분 전 작성"
+        }
+
+        if (duration.toHours() < 24) {
+            val leftHours = duration.toHours().toString()
+            return leftHours + "시간 전 작성"
+        }
+
+        if (duration.toDays() < 31) {
+            val leftDays = duration.toDays().toString()
+            return leftDays + "일 전 작성"
+        }
+
+        return surveyedAt.format(yyyyMMddFormatter) + " 작성"
+    }
+
+    companion object {
+        val yyyyMMddFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+        val TIME_ZONE_SEOUL = ZoneId.of("Asia/Seoul")
+    }
+}

--- a/feature/survey-check/src/main/java/com/wap/wapp/feature/survey/check/SurveyItemCard.kt
+++ b/feature/survey-check/src/main/java/com/wap/wapp/feature/survey/check/SurveyItemCard.kt
@@ -10,7 +10,9 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wap.designsystem.WappTheme
 import com.wap.wapp.core.model.survey.Survey
@@ -30,31 +32,35 @@ internal fun SurveyItemCard(
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(16.dp),
         ) {
             Row(
                 horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(
                     text = survey.title,
-                    modifier = Modifier.weight(1f),
-                    maxLines = 1,
                     color = WappTheme.colors.white,
                     style = WappTheme.typography.titleBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
                 )
 
                 Text(
-                    text = survey.eventName,
-                    color = WappTheme.colors.grayA2,
+                    text = survey.calculateSurveyedAt(),
+                    color = WappTheme.colors.yellow34,
                     style = WappTheme.typography.captionMedium,
+                    modifier = Modifier.padding(start = 8.dp),
                 )
             }
 
             Text(
-                text = survey.userName,
+                text = "${survey.userName} • ${survey.eventName}",
                 color = WappTheme.colors.grayBD,
-                style = WappTheme.typography.contentMedium,
+                style = WappTheme.typography.labelMedium,
+                maxLines = 1,
             )
         }
     }

--- a/feature/survey/src/main/java/com/wap/wapp/feature/survey/SurveyFormItemCard.kt
+++ b/feature/survey/src/main/java/com/wap/wapp/feature/survey/SurveyFormItemCard.kt
@@ -10,7 +10,9 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wap.designsystem.WappTheme
 import com.wap.wapp.core.model.survey.SurveyForm
@@ -34,26 +36,29 @@ internal fun SurveyFormItemCard(
         ) {
             Row(
                 horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(
                     text = surveyForm.title,
                     color = WappTheme.colors.white,
                     modifier = Modifier.weight(1f),
-                    maxLines = 1,
                     style = WappTheme.typography.titleBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
                 Text(
                     text = surveyForm.calculateDeadline(),
                     color = WappTheme.colors.yellow34,
                     style = WappTheme.typography.captionMedium,
+                    modifier = Modifier.padding(start = 8.dp),
                 )
             }
             Text(
                 text = surveyForm.content,
                 color = WappTheme.colors.grayBD,
                 maxLines = 1,
-                style = WappTheme.typography.contentMedium,
+                style = WappTheme.typography.labelMedium,
             )
         }
     }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#140 설문 관리 페이지 UI 개선 및 Dummy Data 소거 

## 2. 🔥 변경된 점
1. 설문 모델이 매핑되는 행사 정보가, 더미 데이터에서 실제 행사 정보로 변경되었습니다
2. UI를 개선했습니다. [피그마 링크](https://www.figma.com/file/ldfJcNruLXpb7e41P7LK3O/WAPP?type=design&node-id=0-1&mode=design&t=yJbFeSaW3qwiWfhp-0)
3. SurveyFormItemCard와 (surveySurveyItemCard의 디자인을 통일했습니다 (글자 크기, 색상, 배치)

## 3. ✅ 꼭 확인해줬으면 하는 부분 
피그마에 설문 정렬 및 검색 기능이 포함된 디자인으로 만들어놨는데 
피그마 내 코멘트 확인 부탁드립니다 !

(현재 이슈와 별개의 기능이라서 따로 정렬 버튼을 구현하지 않았습니다.)

## 4. 📸 스크린샷(선택)

이전 설문 확인 디자인
<img width="256" alt="image" src="https://github.com/pknu-wap/WAPP/assets/77484719/82900d8f-b488-477f-a41c-5753cb903493">

구현 디자인 
<img width="256" alt="image" src="https://github.com/pknu-wap/WAPP/assets/77484719/fa9b5e52-2a48-4d90-b445-49bacd7bb764">

피그마 디자인 
<img width="256" alt="image" src="https://github.com/pknu-wap/WAPP/assets/77484719/02b8216c-e886-4eed-90ef-a065d35ac68b">


## 5. 💡알게된 혹은 궁금한 사항들
Compose Text 속성중 OverFlow를 활용하면 글자가 넘겼을 때 ...으로 처리할 수 있다. 
[Compose Text Overflow](https://kotlinworld.com/221)

