### PR TITLE
Refactor/tgyuu/#148

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="deploymentTargetDropDown">
     <value>
-      <entry key="app">
+      <entry key="MainActivity">
         <State />
       </entry>
     </value>

--- a/core/designsystem/src/main/java/com/wap/designsystem/Color.kt
+++ b/core/designsystem/src/main/java/com/wap/designsystem/Color.kt
@@ -13,6 +13,7 @@ val Gray95 = Color(0xFF959595)
 val Gray82 = Color(0xFF828282)
 val Gray7C = Color(0xFF7C7C7C)
 val Gray4A = Color(0xFF49494A)
+val Black20 = Color(0xFF202022)
 val Black25 = Color(0xFF252424)
 val Black42 = Color(0xFF424242)
 val Black = Color(0xFF000000)
@@ -36,6 +37,7 @@ class WappColor(
     white: Color = Color(0xFFFFFFFF),
     black: Color = Color(0xFF000000),
     backgroundBlack: Color = Color(0xFF131313),
+    black20: Color = Color(0xFF202022),
     black25: Color = Color(0xFF252424),
     black42: Color = Color(0xFF424242),
     gray95: Color = Color(0xFF959595),
@@ -61,6 +63,8 @@ class WappColor(
     var black by mutableStateOf(black)
         private set
     var backgroundBlack by mutableStateOf(backgroundBlack)
+        private set
+    var black20 by mutableStateOf(black20)
         private set
     var black25 by mutableStateOf(black25)
         private set

--- a/feature/notice/src/main/java/com/wap/wapp/feature/notice/NoticeScreen.kt
+++ b/feature/notice/src/main/java/com/wap/wapp/feature/notice/NoticeScreen.kt
@@ -93,7 +93,7 @@ internal fun NoticeScreen(
                 onCalendarMonthChanged = onCalendarMonthChanged,
                 measureDefaultModifier = Modifier
                     .fillMaxWidth()
-                    .background(WappTheme.colors.black25)
+                    .background(WappTheme.colors.black20)
                     .layout { measurable, constraints ->
                         val placeable = measurable.measure(constraints)
 

--- a/feature/notice/src/main/java/com/wap/wapp/feature/notice/NoticeScreen.kt
+++ b/feature/notice/src/main/java/com/wap/wapp/feature/notice/NoticeScreen.kt
@@ -74,6 +74,7 @@ internal fun NoticeScreen(
             scaffoldState = scaffoldState,
             sheetContainerColor = WappTheme.colors.black25,
             sheetPeekHeight = defaultHeight,
+            sheetShadowElevation = 20.dp,
             sheetContent = {
                 BottomSheetContent(
                     expandableHeight = expandableHeight,


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- closed #148 

## 2. 🔥 변경된 점

- **바텀 시트, 달력 색상이 같아서 구분이 어렵던 이슈** 해결
- **바텀시트 상단에 그림자 추가**

## 3. ✅ 꼭 확인해줬으면 하는 부분 

## 4. 📸 스크린샷(선택)

**기존**

![image](https://github.com/pknu-wap/WAPP/assets/116813010/61b6dba5-2470-4f05-9e23-7dc6be44719c)

<br><br><br>

**변경**

![image](https://github.com/pknu-wap/WAPP/assets/116813010/9fd648ac-3019-44a8-84d2-6007de2d99b6)

## 5. 💡알게된 혹은 궁금한 사항들

바텀 시트에 그림자 추가하는 방법 매우 간단했다...

바텀 시트 속성 중에 `sheetShadowElevation = 20.dp` 로 그림자 넣기를 제공해주고 있었따 (허거덩)